### PR TITLE
Reduce server error/warning log spam

### DIFF
--- a/gfg_interactive/example_config.py
+++ b/gfg_interactive/example_config.py
@@ -5,6 +5,8 @@ class Config(object):
     TESTING = False
     CSRF_ENABLED = True
     SECRET_KEY = 'enter key here'
+    ## TODO: Default setting will suppress log warnings in minimally invasive fashion. If we are confident no signals are used, better to switch to `False`.
+    SQLALCHEMY_TRACK_MODIFICATIONS = True
 
 class ProductionConfig(Config):
     DEBUG = False


### PR DESCRIPTION
## Ticket
https://phab.sph.umich.edu/T71

## Purpose
Most of the lines in production server error logs are related to a generic Interactive Survey Module warning, and a small config change could make this less noisy.

> [Mon Aug 07 07:10:xx.xxxxxx 20xx] [:error] [pid xxxx] warnings.warn('SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future. Set it to True to suppress this warning.')

This log warning can be suppressed by adding `True` or `False` explicitly to the setting (as described in error message).

### Question
The ISM code does not appear to use signals. Changing to setting to "True" would be the minimally invasive solution to reduce log spam- but we should choose a default that reflects what the app really does.

On production today, this warning appears in ~4k out of 121k lines total.

## Testing notes
I will test this once I have the app running locally.

## Deployment considerations
Due to the configuration file mechanism, this change will require configuration changes to all servers where ISM is already deployed.