### PR TITLE
Change default mechanism for sending user ids

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ MySQL-python==1.2.5
 python-editor==1.0.1
 SQLAlchemy==1.0.13
 Werkzeug==0.11.10
-pycrypto==2.6.1
+pycryptodome==3.6.6


### PR DESCRIPTION
# Ticket
https://phab.sph.umich.edu/T174

# Purpose
- Replace a deprecated library with a maintained fork
- Change the default algorithm used to communicate between apps, to reflect changes made on the PHP side. 

# Deployment notes
- The `config.py` integration key must be changed to a new random 32 character value (and it must match the value used in php). 
 (`Config.SECRET_KEY` in  `/srv/www/genesforgood/etc/gfg_interactive_config.py`)

Although php openssl does not enforce key length, pycryptodome does, and decryption will fail if the key does not meet the requirements.