### PR TITLE
fixed result template when rendering into the core

### DIFF
--- a/gfg_interactive/exp/templates/category_switch/results.html
+++ b/gfg_interactive/exp/templates/category_switch/results.html
@@ -1,8 +1,10 @@
-{% extends "base.html" %}
-{% block content %}
+{% if not content_only %}
+  {% extends "base.html" %}
 <br><br>
-<div class = "container">
-    <div class="well">
+{% endif %}
+
+{% block content %}
+    <div>
 
         <h2>You made it! Thank you!</h2>
 
@@ -31,8 +33,8 @@
         <h2>Why do we measure executive functions?</h2>
         Executive functions help us all navigate the complex world we live in. They help us multi-task, plan for the future, stay on task, complete goals, and remembering to remember ("I need to remember to go to the grocery store after work"). Executive functions are related to many health outcomes and mental health outcomes, such as decline in neurodegenerative diseases such as Alzheimer's or Parkinsons.
         </p>
-
+{% if not content_only %}
     </div>
     <button type="button" class="btn btn-primary" onclick="opener.closeInteractiveSurvey(); window.close()">Back to Genes for Good</button>
-</div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Purpose
Fixed the template that renders `Category Switch` survey result into the core survey result browser. See original screenshot below with wrong format.

![category_switch_result_screenshot](https://user-images.githubusercontent.com/10710777/47306347-2b4ff200-d5fa-11e8-9d65-81b18687e238.jpg)

After the fix, it just shows plain text instead.  
